### PR TITLE
Don't define /cache volume on register, its by default when cache is enabled.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ runner_name:
 gitlab_url: https://gitlab.com/
 
 # registration token provided by the gitlab server
-registration_token:
+registration_token: ""
 
 # the tag of the GitLab runner docker image to be run, see https://hub.docker.com/r/gitlab/gitlab-runner/tags/
 image_tag: alpine-v10.3.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: Check required var registration_token is set
+  fail:
+    msg: "registration_token var is not set"
+  when: registration_token | length == 0
+
 - name: pip install docker-py
   pip:
     name: docker-py

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,6 @@
     --run-untagged={{ run_untagged }}
     --docker-privileged
     --docker-disable-cache=false
-    --docker-volumes=/var/cache:/cache:rw
     --docker-volumes=/var/run/docker.sock:/var/run/docker.sock
 
 - name: set concurrency parameter in gitlab-runner's config.toml


### PR DESCRIPTION
Hi,

I think Gitlab introduced a bug with the detection of user defined cache volume. (It does not work) : 
https://gitlab.com/gitlab-org/gitlab-runner/blob/master/CHANGELOG.md#v1050-2018-02-22

My test with cache volume not defined in register, you can see that the cache volume is still set in /etc/gitlab-runner/config.toml. (Tested with gitlab-runner 13.4.0)
```
    volumes = ["/var/run/docker.sock:/var/run/docker.sock", "/cache"]
```

Regards,
